### PR TITLE
Consider auto-populating DD_* env vars with sensible defaults

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,9 @@ async function run(): Promise<void> {
     if (code !== 0) throw new Error(`could not start agent: (${code})`)
 
     core.info('Agent started')
+    
+    core.exportVariable('DD_ENV', 'ci')
+    core.exportVariable('DD_SERVICE', process.env.GITHUB_REPOSITORY)
   } catch (error) {
     if (error instanceof Error) core.setFailed(error.message)
   }


### PR DESCRIPTION
While trying to set up Datadog CI tests integration, for a while I thought the following steps were all that was necessary:

<img width="699" alt="CleanShot 2022-01-28 at 18 05 49@2x" src="https://user-images.githubusercontent.com/369053/151502688-0c5efc20-8acb-457e-a05b-0be77f2f1604.png">

It took me a while to realise that I also needed to set the following environment variables:

<img width="1039" alt="CleanShot 2022-01-28 at 18 06 11@2x" src="https://user-images.githubusercontent.com/369053/151502799-cbd46c85-456b-4b62-9598-2e57e324b23c.png">

Perhaps it would be useful to have this action set those environment variables by default? This PR probably shouldn't be merged as-is, it's more a demo of what I am suggesting. Feel free to close this PR and implement it yourself with docs, etc.