### PR TITLE
Update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "@actions/exec": "^1.1.0"
       },
       "devDependencies": {
-        "@types/node": "^17.0.10",
-        "@typescript-eslint/eslint-plugin": "^5.10.1",
-        "@typescript-eslint/parser": "^5.10.1",
+        "@types/node": "^17.0.13",
+        "@typescript-eslint/eslint-plugin": "^5.10.2",
+        "@typescript-eslint/parser": "^5.10.2",
         "@vercel/ncc": "^0.33.1",
-        "eslint": "^8.7.0",
+        "eslint": "^8.8.0",
         "eslint-plugin-github": "^4.3.5",
         "eslint-plugin-jest": "^26.0.0",
         "jest": "^27.4.7",
@@ -1524,9 +1524,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
-      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
+      "version": "17.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
+      "integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1557,14 +1557,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.2.tgz",
+      "integrity": "sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/type-utils": "5.10.2",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -1605,14 +1605,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.2.tgz",
+      "integrity": "sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -1632,13 +1632,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
+      "integrity": "sha512-39Tm6f4RoZoVUWBYr3ekS75TYgpr5Y+X0xLZxXqcZNDWZdJdYbKd3q2IR4V9y5NxxiPu/jxJ8XP7EgHiEQtFnw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1"
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1649,12 +1649,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.2.tgz",
+      "integrity": "sha512-uRKSvw/Ccs5FYEoXW04Z5VfzF2iiZcx8Fu7DGIB7RHozuP0VbKNzP1KfZkHBTM75pCpsWxIthEH1B33dmGBKHw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -1675,9 +1675,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.2.tgz",
+      "integrity": "sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1688,13 +1688,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.2.tgz",
+      "integrity": "sha512-WHHw6a9vvZls6JkTgGljwCsMkv8wu8XU8WaYKeYhxhWXH/atZeiMW6uDFPLZOvzNOGmuSMvHtZKd6AuC8PrwKQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -1730,15 +1730,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.2.tgz",
+      "integrity": "sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -1754,12 +1754,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz",
+      "integrity": "sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -2667,9 +2667,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.0.5",
@@ -8853,9 +8853,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.10.tgz",
-      "integrity": "sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==",
+      "version": "17.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.14.tgz",
+      "integrity": "sha512-SbjLmERksKOGzWzPNuW7fJM7fk3YXVTFiZWB/Hs99gwhk+/dnrQRPBQjPW9aO+fi1tAffi9PrwFvsmOKmDTyng==",
       "dev": true
     },
     "@types/prettier": {
@@ -8886,14 +8886,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.1.tgz",
-      "integrity": "sha512-xN3CYqFlyE/qOcy978/L0xLR2HlcAGIyIK5sMOasxaaAPfQRj/MmMV6OC3I7NZO84oEUdWCOju34Z9W8E0pFDQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.10.2.tgz",
+      "integrity": "sha512-4W/9lLuE+v27O/oe7hXJKjNtBLnZE8tQAFpapdxwSVHqtmIoPB1gph3+ahNwVuNL37BX7YQHyGF9Xv6XCnIX2Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/type-utils": "5.10.1",
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/type-utils": "5.10.2",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -8914,52 +8914,52 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.1.tgz",
-      "integrity": "sha512-GReo3tjNBwR5RnRO0K2wDIDN31cM3MmDtgyQ85oAxAmC5K3j/g85IjP+cDfcqDsDDBf1HNKQAD0WqOYL8jXqUA==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.10.2.tgz",
+      "integrity": "sha512-JaNYGkaQVhP6HNF+lkdOr2cAs2wdSZBoalE22uYWq8IEv/OVH0RksSGydk+sW8cLoSeYmC+OHvRyv2i4AQ7Czg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.1.tgz",
-      "integrity": "sha512-Lyvi559Gvpn94k7+ElXNMEnXu/iundV5uFmCUNnftbFrUbAJ1WBoaGgkbOBm07jVZa682oaBU37ao/NGGX4ZDg==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.10.2.tgz",
+      "integrity": "sha512-39Tm6f4RoZoVUWBYr3ekS75TYgpr5Y+X0xLZxXqcZNDWZdJdYbKd3q2IR4V9y5NxxiPu/jxJ8XP7EgHiEQtFnw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1"
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.1.tgz",
-      "integrity": "sha512-AfVJkV8uck/UIoDqhu+ptEdBoQATON9GXnhOpPLzkQRJcSChkvD//qsz9JVffl2goxX+ybs5klvacE9vmrQyCw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.10.2.tgz",
+      "integrity": "sha512-uRKSvw/Ccs5FYEoXW04Z5VfzF2iiZcx8Fu7DGIB7RHozuP0VbKNzP1KfZkHBTM75pCpsWxIthEH1B33dmGBKHw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.10.1",
+        "@typescript-eslint/utils": "5.10.2",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.1.tgz",
-      "integrity": "sha512-ZvxQ2QMy49bIIBpTqFiOenucqUyjTQ0WNLhBM6X1fh1NNlYAC6Kxsx8bRTY3jdYsYg44a0Z/uEgQkohbR0H87Q==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.10.2.tgz",
+      "integrity": "sha512-Qfp0qk/5j2Rz3p3/WhWgu4S1JtMcPgFLnmAKAW061uXxKSa7VWKZsDXVaMXh2N60CX9h6YLaBoy9PJAfCOjk3w==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.1.tgz",
-      "integrity": "sha512-PwIGnH7jIueXv4opcwEbVGDATjGPO1dx9RkUl5LlHDSe+FXxPwFL5W/qYd5/NHr7f6lo/vvTrAzd0KlQtRusJQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.10.2.tgz",
+      "integrity": "sha512-WHHw6a9vvZls6JkTgGljwCsMkv8wu8XU8WaYKeYhxhWXH/atZeiMW6uDFPLZOvzNOGmuSMvHtZKd6AuC8PrwKQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/visitor-keys": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/visitor-keys": "5.10.2",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -8979,26 +8979,26 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.1.tgz",
-      "integrity": "sha512-RRmlITiUbLuTRtn/gcPRi4202niF+q7ylFLCKu4c+O/PcpRvZ/nAUwQ2G00bZgpWkhrNLNnvhZLbDn8Ml0qsQw==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.10.2.tgz",
+      "integrity": "sha512-vuJaBeig1NnBRkf7q9tgMLREiYD7zsMrsN1DA3wcoMDvr3BTFiIpKjGiYZoKPllfEwN7spUjv7ZqD+JhbVjEPg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.10.1",
-        "@typescript-eslint/types": "5.10.1",
-        "@typescript-eslint/typescript-estree": "5.10.1",
+        "@typescript-eslint/scope-manager": "5.10.2",
+        "@typescript-eslint/types": "5.10.2",
+        "@typescript-eslint/typescript-estree": "5.10.2",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.1.tgz",
-      "integrity": "sha512-NjQ0Xinhy9IL979tpoTRuLKxMc0zJC7QVSdeerXs2/QvOy2yRkzX5dRb10X5woNUdJgU8G3nYRDlI33sq1K4YQ==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.10.2.tgz",
+      "integrity": "sha512-zHIhYGGGrFJvvyfwHk5M08C5B5K4bewkm+rrvNTKk1/S15YHR+SA/QUF8ZWscXSfEaB8Nn2puZj+iHcoxVOD/Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.10.1",
+        "@typescript-eslint/types": "5.10.2",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -9688,9 +9688,9 @@
       }
     },
     "eslint": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.7.0.tgz",
-      "integrity": "sha512-ifHYzkBGrzS2iDU7KjhCAVMGCvF6M3Xfs8X8b37cgrUlDt6bWRTpRh6T/gtSXv1HJ/BUGgmjvNvOEGu85Iif7w==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+      "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "@actions/exec": "^1.1.0"
   },
   "devDependencies": {
-    "@types/node": "^17.0.10",
-    "@typescript-eslint/eslint-plugin": "^5.10.1",
-    "@typescript-eslint/parser": "^5.10.1",
+    "@types/node": "^17.0.13",
+    "@typescript-eslint/eslint-plugin": "^5.10.2",
+    "@typescript-eslint/parser": "^5.10.2",
     "@vercel/ncc": "^0.33.1",
-    "eslint": "^8.7.0",
+    "eslint": "^8.8.0",
     "eslint-plugin-github": "^4.3.5",
     "eslint-plugin-jest": "^26.0.0",
     "jest": "^27.4.7",


### PR DESCRIPTION
- Bump @types/node from 17.0.10 to 17.0.13
- Bump @typescript-eslint/parser from 5.10.1 to 5.10.2
- Bump @typescript-eslint/eslint-plugin from 5.10.1 to 5.10.2
- Bump eslint from 8.7.0 to 8.8.0